### PR TITLE
Resolve jitter, remove physics tweaks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,12 @@ categories = ["game-development"]
 
 [dependencies]
 bevy = { version = "0.8", default-features = false, features = ["bevy_render"]}
-bevy_rapier3d = { version = "0.16.0", default-features = false, features = ["dim3"]}
+bevy_rapier3d = { version = "0.16", default-features = false, features = ["dim3"]}
 
 [dev-dependencies]
 # bevy_editor_pls = { git = "https://github.com/jakobhellermann/bevy_editor_pls" }
 bevy = "0.8"
-bevy_rapier3d = { version = "0.16.0", features = ["debug-render"]}
+bevy_rapier3d = { version = "0.16", features = ["debug-render"]}
 
 # Enable only a small amount of optimization in debug mode
 [profile.dev]


### PR DESCRIPTION
Depends on https://github.com/dimforge/bevy_rapier/pull/248, which has been merged but there has not been a release yet.
When compiling with this fix, the jitter is completely gone.