### PR TITLE
Add Rapier2d support [don't merge! Read description first!]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,18 @@ categories = ["game-development"]
 
 [dependencies]
 bevy = { version = "0.8", default-features = false, features = ["bevy_render"]}
-bevy_rapier3d = { version = "0.16", default-features = false, features = ["dim3"]}
+bevy_rapier3d = { version = "0.16", default-features = false, optional = true, features = ["dim3"]}
+bevy_rapier2d = { version = "0.16", default-features = false, optional = true, features = ["dim2"]}
+
+[features]
+rapier2d = ["bevy_rapier2d"]
+rapier3d = ["bevy_rapier3d"]
 
 [dev-dependencies]
 # bevy_editor_pls = { git = "https://github.com/jakobhellermann/bevy_editor_pls" }
 bevy = "0.8"
 bevy_rapier3d = { version = "0.16", features = ["debug-render"]}
+bevy_rapier2d = { version = "0.16", features = ["debug-render"]}
 
 # Enable only a small amount of optimization in debug mode
 [profile.dev]
@@ -30,3 +36,19 @@ opt-level = 1
 # Enable high optimizations for dependencies (incl. Bevy), but not for our code:
 [profile.dev.package."*"]
 opt-level = 3
+
+[[example]]
+name = "first_person"
+required-features = ["rapier3d"]
+
+[[example]]
+name = "platformer_2d"
+required-features = ["rapier2d"]
+
+[[example]]
+name = "starship"
+required-features = ["rapier3d"]
+
+[[example]]
+name = "starship_2d"
+required-features = ["rapier2d"]

--- a/README.md
+++ b/README.md
@@ -15,13 +15,17 @@ and highly customizable.
 Wanderlust does not handle mouselook, as it's more-or-less trivial to implement compared to movement, and would add significant complexity to build in
 as many projects will have vastly different requirements for mouselook. The `first_person.rs` example includes an example mouselook implementation.
 
-To use Wanderlust, simply add the [`WanderlustPlugin`](plugins::WanderlustPlugin) to your `App`, and create an entity with the [`CharacterControllerBundle`](bundles::CharacterControllerBundle). 
+To use Wanderlust, simply add the [`WanderlustPlugin`](plugins::WanderlustPlugin) to your `App`, and create an entity with the [`CharacterControllerBundle`](bundles::CharacterControllerBundle). The generic parameter for these types can be obtained from the `backends` module after enabling the appropriate features:
+
+* Enable the `rapier2d` feature to expose [`Rapier2dBackend`](backends::Rapier2dBackend) to use as a parameter for `WanderlustPlugin` and
+  [`Rapier2dControllerPhysicsBundle`](backends::Rapier2dControllerPhysicsBundle) to use as generic parameter for `CharacterControllerBundle`.
+* Enable the `rapier3d` feature to expose [`Rapier3dBackend`](backends::Rapier3dBackend) to use as a parameter for `WanderlustPlugin` and
+  [`Rapier3dControllerPhysicsBundle`](backends::Rapier3dControllerPhysicsBundle) to use as generic parameter for `CharacterControllerBundle`.
 
 ## Planned Features
 - Wallrunning
 - Be more agnostic to up-vectors
 - More examples
-  - 2D
   - Mario-Galaxy-style planetoids
   - Moving platforms
 - Fix various jitter issues
@@ -38,7 +42,9 @@ Wanderlust is intended to cover nearly every possible use case of a character co
 please drop an issue on the repository! PRs are also welcome, but I may not accept all PRs. Open an issue first if you're not certain that I would accept.
 
 ## Examples
-The `first_person.rs` example which shows a simple character controller setup.
-The `starship.rs` example which shows a simple spaceship controller setup.
+The `first_person.rs` example which shows a simple 3D character controller setup. Requires `--features=rapier3d`.
+The `platformer_2d.rs` example which shows a simple 2D character controller setup. Requires `--features=rapier2d`.
+The `starship.rs` example which shows a simple spaceship controller setup. Requires `--features=rapier3d`.
+The `starship.rs` example which shows a simple asteroids-like spaceship controller setup. Requires `--features=rapier2d`.
 
 Dual-licensed under MIT OR Apache 2.0.

--- a/examples/first_person.rs
+++ b/examples/first_person.rs
@@ -2,6 +2,7 @@
 
 use bevy::render::camera::Projection;
 use bevy::{input::mouse::MouseMotion, prelude::*};
+use bevy_mod_wanderlust::backends::Rapier3dBackend;
 // use bevy_editor_pls::prelude::*;
 use bevy_mod_wanderlust::{CharacterControllerBundle, ControllerInput, WanderlustPlugin};
 use bevy_rapier3d::prelude::*;
@@ -11,7 +12,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
         .add_plugin(RapierDebugRenderPlugin::default())
-        .add_plugin(WanderlustPlugin)
+        .add_plugin(WanderlustPlugin(Rapier3dBackend))
         .insert_resource(Sensitivity(0.15))
         .add_startup_system(setup)
         // Add to PreUpdate to ensure updated before movement is calculated
@@ -49,7 +50,7 @@ fn setup(
     let material = mats.add(Color::WHITE.into());
 
     commands
-        .spawn_bundle(CharacterControllerBundle::default())
+        .spawn_bundle(CharacterControllerBundle::<Rapier3dBackend>::default())
         .insert_bundle(PbrBundle {
             mesh,
             material: material.clone(),

--- a/examples/platformer_2d.rs
+++ b/examples/platformer_2d.rs
@@ -1,0 +1,87 @@
+//! A simple example of setting up a 2D platformer character controlled player.
+
+use bevy::prelude::*;
+use bevy_mod_wanderlust::backends::Rapier2dBackend;
+use bevy_mod_wanderlust::{CharacterControllerBundle, ControllerInput, WanderlustPlugin};
+use bevy_rapier2d::prelude::*;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
+        .add_plugin(RapierDebugRenderPlugin::default())
+        .add_plugin(WanderlustPlugin(Rapier2dBackend))
+        .insert_resource(Sensitivity(0.15))
+        .add_startup_system(setup)
+        // Add to PreUpdate to ensure updated before movement is calculated
+        .add_system_to_stage(CoreStage::PreUpdate, movement_input)
+        .run()
+}
+
+#[derive(Component, Default, Reflect)]
+#[reflect(Component)]
+struct PlayerCam;
+
+#[derive(Component, Default, Reflect)]
+#[reflect(Component)]
+struct PlayerBody;
+
+#[derive(Reflect)]
+struct Sensitivity(f32);
+
+fn setup(mut commands: Commands) {
+    commands.spawn_bundle(Camera2dBundle {
+        transform: Transform::from_xyz(0.0, 0.0, 100.0).with_scale(Vec3::new(0.03, 0.02, 1.0)),
+        ..default()
+    });
+
+    commands
+        .spawn_bundle(CharacterControllerBundle::<Rapier2dBackend>::default())
+        .insert_bundle(SpatialBundle::default())
+        .insert_bundle((Name::from("Player"), PlayerBody));
+
+    commands
+        .spawn_bundle(SpatialBundle {
+            transform: Transform::from_xyz(0.0, -3.0, 0.0),
+            ..default()
+        })
+        .insert_bundle((Collider::cuboid(10.0, 0.5), Name::from("Ground")));
+
+    commands
+        .spawn_bundle(SpatialBundle {
+            transform: Transform::from_xyz(-6.5, -1.0, 0.0).with_rotation(Quat::from_euler(
+                EulerRot::XYZ,
+                0.0,
+                0.0,
+                0.9,
+            )),
+            ..default()
+        })
+        .insert_bundle((Name::from("Slope"), Collider::cuboid(0.5, 3.0)));
+
+    commands
+        .spawn_bundle(SpatialBundle {
+            transform: Transform::from_xyz(6.5, -1.0, 0.0),
+            ..default()
+        })
+        .insert_bundle((Name::from("Wall"), Collider::cuboid(0.25, 3.0)));
+}
+
+fn movement_input(
+    mut body: Query<&mut ControllerInput, With<PlayerBody>>,
+    input: Res<Input<KeyCode>>,
+) {
+    let mut player_input = body.single_mut();
+
+    let mut dir = Vec3::ZERO;
+    if input.pressed(KeyCode::Left) {
+        dir += -Vec3::X;
+    }
+    if input.pressed(KeyCode::Right) {
+        dir += Vec3::X
+    }
+    dir.y = 0.0;
+    player_input.movement = dir;
+
+    player_input.jumping = input.pressed(KeyCode::Up);
+}

--- a/examples/starship_2d.rs
+++ b/examples/starship_2d.rs
@@ -1,34 +1,16 @@
 use std::f32::consts::FRAC_PI_2;
 
-use bevy::input::mouse::MouseMotion;
 use bevy::prelude::*;
-use bevy_mod_wanderlust::backends::{Rapier3dBackend, Rapier3dControllerPhysicsBundle};
-// use bevy_editor_pls::controls::{Action, Binding, Button, EditorControls, UserInput};
-// use bevy_editor_pls::prelude::*;
+use bevy_mod_wanderlust::backends::{Rapier2dBackend, Rapier2dControllerPhysicsBundle};
 use bevy_mod_wanderlust::{ControllerInput, StarshipControllerBundle, WanderlustPlugin};
-use bevy_rapier3d::plugin::{NoUserData, RapierPhysicsPlugin};
-use bevy_rapier3d::prelude::Damping;
+use bevy_rapier2d::plugin::{NoUserData, RapierPhysicsPlugin};
+use bevy_rapier2d::prelude::Damping;
 
 fn main() {
-    // let mut bindings = EditorControls::default_bindings();
-    // bindings.unbind(Action::PlayPauseEditor);
-    // bindings.insert(
-    //     Action::PlayPauseEditor,
-    //     Binding {
-    //         input: UserInput::Chord(vec![
-    //             Button::Keyboard(KeyCode::LControl),
-    //             Button::Keyboard(KeyCode::E),
-    //         ]),
-    //         conditions: vec![],
-    //     },
-    // );
-
     App::new()
         .add_plugins(DefaultPlugins)
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
-        .add_plugin(WanderlustPlugin(Rapier3dBackend))
-        // .add_plugin(EditorPlugin)
-        // .insert_resource(bindings)
+        .add_plugin(WanderlustPlugin(Rapier2dBackend))
         .add_startup_system(setup)
         .add_system_to_stage(CoreStage::PreUpdate, input)
         .register_type::<Player>()
@@ -52,7 +34,7 @@ fn setup(
     c.spawn_bundle(PbrBundle {
         mesh,
         material: mat.clone(),
-        transform: Transform::from_xyz(0.0, 0.0, 0.0),
+        transform: Transform::from_xyz(0.0, 0.0, -10.0),
         ..default()
     });
 
@@ -69,9 +51,9 @@ fn setup(
     });
 
     // The ship itself
-    c.spawn_bundle(StarshipControllerBundle::<Rapier3dBackend> {
+    c.spawn_bundle(StarshipControllerBundle::<Rapier2dBackend> {
         transform: Transform::from_xyz(0.0, 0.0, 5.0),
-        physics: Rapier3dControllerPhysicsBundle {
+        physics: Rapier2dControllerPhysicsBundle {
             damping: Damping {
                 angular_damping: 0.5,
                 linear_damping: 0.5,
@@ -85,63 +67,50 @@ fn setup(
         c.spawn_bundle(SceneBundle {
             transform: Transform::from_translation(Vec3::ZERO).with_rotation(Quat::from_euler(
                 EulerRot::XYZ,
-                0.0,
+                FRAC_PI_2,
                 -FRAC_PI_2,
                 0.0,
             )),
             scene: ass.load("gltf/starship.glb#Scene0"),
             ..default()
         });
-
-        c.spawn_bundle(Camera3dBundle {
-            transform: Transform::from_xyz(0.0, 7.5, 35.0),
-            ..default()
-        });
+    });
+    c.spawn_bundle(Camera3dBundle {
+        transform: Transform::from_xyz(0.0, 0.0, 100.0),
+        ..default()
     });
 }
 
 fn input(
     mut body: Query<(&mut ControllerInput, &GlobalTransform)>,
     input: Res<Input<KeyCode>>,
-    mut mouse: EventReader<MouseMotion>,
     time: Res<Time>,
 ) {
-    const SENSITIVITY: f32 = 0.025;
-    const ROLL_MULT: f32 = 5.0;
+    const ROLL_MULT: f32 = 1.0;
 
     let (mut body, tf) = body.single_mut();
 
     let mut dir = Vec3::ZERO;
-    if input.pressed(KeyCode::A) {
+    if input.pressed(KeyCode::Q) {
         dir += -tf.right();
     }
-    if input.pressed(KeyCode::D) {
+    if input.pressed(KeyCode::E) {
         dir += tf.right();
     }
     if input.pressed(KeyCode::S) {
-        dir += -tf.forward();
-    }
-    if input.pressed(KeyCode::W) {
-        dir += tf.forward();
-    }
-    if input.pressed(KeyCode::LControl) {
         dir += -tf.up();
     }
-    if input.pressed(KeyCode::Space) {
+    if input.pressed(KeyCode::W) {
         dir += tf.up();
     }
 
     body.movement = dir;
 
     let dt = time.delta_seconds();
-    for &MouseMotion { delta } in mouse.iter() {
-        body.custom_torque += tf.up() * -delta.x * dt * SENSITIVITY;
-        body.custom_torque += tf.right() * -delta.y * dt * SENSITIVITY;
+    if input.pressed(KeyCode::A) {
+        body.custom_torque += -tf.forward() * dt * ROLL_MULT;
     }
-    if input.pressed(KeyCode::Q) {
-        body.custom_torque += -tf.forward() * dt * SENSITIVITY * ROLL_MULT;
-    }
-    if input.pressed(KeyCode::E) {
-        body.custom_torque += tf.forward() * dt * SENSITIVITY * ROLL_MULT;
+    if input.pressed(KeyCode::D) {
+        body.custom_torque += tf.forward() * dt * ROLL_MULT;
     }
 }

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -1,0 +1,105 @@
+//! This module contains the [PhysicsBackend] trait, and its submodules implement it for various
+//! physics backends.
+
+use bevy::prelude::*;
+
+#[cfg(feature = "rapier2d")]
+mod rapier2d;
+#[cfg(feature = "rapier2d")]
+pub use rapier2d::{Rapier2dBackend, Rapier2dControllerPhysicsBundle};
+
+#[cfg(feature = "rapier3d")]
+mod rapier3d;
+#[cfg(feature = "rapier3d")]
+pub use rapier3d::{Rapier3dBackend, Rapier3dControllerPhysicsBundle};
+
+/// The trait to implement in order to support a backend.
+///
+/// This trait serves as the generic argument for [`WanderlustPlugin`](crate::WanderlustPlugin) and
+/// for [`CharacterControllerBundle`](crate::WanderlustPlugin).
+pub trait PhysicsBackend: 'static + Send + Sync {
+    /// A bundle of components to add to the player controlled entity as part of
+    /// [`CharacterControllerBundle`](crate::CharacterControllerBundle).
+    ///
+    /// Should `impl` [Default] with sensible defaults, but the values of the components should
+    /// also be overridable by the user.
+    type ControllerPhysicsBundle: Bundle + Default;
+
+    /// A component used by the backend to apply impulses.
+    type ExternalImpulse: Component;
+
+    /// A component used by the backend to represent the linear and angular velocity of the rigid
+    /// body.
+    type Velocity: Component;
+
+    /// A resource that can be used to query the physics engine.
+    type PhysicsContext: Send + Sync;
+
+    /// A component used by the backend to represent a shape that can be cast to determine the
+    /// distance to the ground.
+    type CastableShape: BackendCastableShape;
+
+    /// Generate a setup system that can prepare the backend to be used with Wanderlust.
+    ///
+    /// *Note: Most users will not need to use this directly. Use
+    /// [`WanderlustPlugin`](crate::plugins::WanderlustPlugin) instead. Alternatively, if one
+    /// only wants to disable the system, use
+    /// [`WanderlustPhysicsTweaks`](crate::WanderlustPhysicsTweaks).*
+    fn generate_setup_system_set() -> SystemSet;
+
+    /// Apply impulses to the component that represents impulses.
+    fn apply_impulses(body: &mut Self::ExternalImpulse, impulse: Vec3, torque_impulse: Vec3);
+
+    /// Checks if an entity is in contact with any other collider.
+    fn entity_has_contacts(ctx: &Self::PhysicsContext, entity: Entity) -> bool;
+
+    /// Cast a shape to determine the distance to the ground.
+    fn cast_shape(
+        ctx: &Self::PhysicsContext,
+        transofrm: &GlobalTransform,
+        settings: &crate::ControllerSettings<Self::CastableShape>,
+        entity: Entity,
+    ) -> Option<(Entity, ToiProxy)>;
+
+    /// Extract the linear part from the velocity component.
+    fn extract_linvel(velocity: &Self::Velocity) -> Vec3;
+
+    /// Extract the angular part from the velocity component.
+    fn extract_angvel(velocity: &Self::Velocity) -> Vec3;
+}
+
+/// The result of a time-of-impact (TOI) computation.
+///
+/// Different backends will have different versions of this, so the backend needs to translate them
+/// to this struct. It only contains the fields Wanderlust uses.
+#[derive(Clone, Copy)]
+pub struct ToiProxy {
+    /// The time at which the objects touch.
+    pub toi: f32,
+    /// The local-space outward normal on the first shape at the time of impact.
+    pub normal1: Vec3,
+    /// The way the time-of-impact computation algorithm terminated.
+    pub status: TOIStatusProxy,
+}
+
+/// The status of the time-of-impact computation algorithm.
+///
+/// Different backends will have different versions of this, so the backend needs to translate them
+/// to this enum.
+#[derive(PartialEq, Eq, Clone, Copy)]
+pub enum TOIStatusProxy {
+    /// The TOI algorithm ran out of iterations before achieving convergence.
+    OutOfIterations,
+    /// The TOI algorithm converged successfully.
+    Converged,
+    /// Something went wrong during the TOI computation, likely due to numerical instabilities.
+    Failed,
+    /// The two shape already overlap at the time 0.
+    Penetrating,
+}
+
+/// A trait for generic usage of the castable shape defined by [PhysicsBackend::CastableShape].
+pub trait BackendCastableShape: 'static + Send + Sync {
+    /// Create a castable shape in the shape of a ball.
+    fn ball(radius: f32) -> Self;
+}

--- a/src/backends/rapier2d.rs
+++ b/src/backends/rapier2d.rs
@@ -1,0 +1,146 @@
+//! Implementations specific to the 2D version of Rapier.
+
+use super::{BackendCastableShape, PhysicsBackend, TOIStatusProxy, ToiProxy};
+use bevy::{math::*, prelude::*};
+use bevy_rapier2d::prelude::*;
+
+/// A [PhysicsBackend] for using the 2D version of Rapier.
+pub struct Rapier2dBackend;
+
+impl PhysicsBackend for Rapier2dBackend {
+    type ControllerPhysicsBundle = Rapier2dControllerPhysicsBundle;
+    type ExternalImpulse = ExternalImpulse;
+    type Velocity = Velocity;
+    type PhysicsContext = RapierContext;
+    type CastableShape = Collider;
+
+    /// This system adds some tweaks to rapier's physics settings that make the character controller behave better.
+    fn generate_setup_system_set() -> SystemSet {
+        fn setup_physics_context(
+            mut ctx: ResMut<RapierContext>,
+            should_change: Option<Res<crate::WanderlustPhysicsTweaks>>,
+        ) {
+            if should_change.map(|s| s.should_do_tweaks()).unwrap_or(true) {
+                let params = &mut ctx.integration_parameters;
+                // This prevents any noticeable jitter when running facefirst into a wall.
+                params.erp = 0.99;
+                // This prevents (most) noticeable jitter when running facefirst into an inverted corner.
+                params.max_velocity_iterations = 16;
+                // TODO: Fix jitter that occurs when running facefirst into a normal corner.
+            }
+        }
+        SystemSet::new().with_system(setup_physics_context)
+    }
+
+    fn apply_impulses(body: &mut Self::ExternalImpulse, impulse: Vec3, torque_impulse: Vec3) {
+        body.impulse = impulse.truncate();
+        body.torque_impulse = torque_impulse.z;
+    }
+
+    fn entity_has_contacts(ctx: &Self::PhysicsContext, entity: Entity) -> bool {
+        ctx.contacts_with(entity).next().is_some()
+    }
+
+    fn cast_shape(
+        ctx: &Self::PhysicsContext,
+        transofrm: &GlobalTransform,
+        settings: &crate::ControllerSettings<Self::CastableShape>,
+        entity: Entity,
+    ) -> Option<(Entity, super::ToiProxy)> {
+        ctx.cast_shape(
+            transofrm.mul_vec3(settings.float_cast_origin).truncate(),
+            transofrm
+                .to_scale_rotation_translation()
+                .1
+                .to_axis_angle()
+                .1,
+            -settings.up_vector.truncate(),
+            &settings.float_cast_collider,
+            settings.float_cast_length,
+            QueryFilter::new().predicate(&|collider| collider != entity),
+        )
+        .map(|(entity, toi)| {
+            (
+                entity,
+                ToiProxy {
+                    toi: toi.toi,
+                    normal1: toi.normal1.extend(0.0),
+                    status: match toi.status {
+                        TOIStatus::OutOfIterations => TOIStatusProxy::OutOfIterations,
+                        TOIStatus::Converged => TOIStatusProxy::Converged,
+                        TOIStatus::Failed => TOIStatusProxy::Failed,
+                        TOIStatus::Penetrating => TOIStatusProxy::Penetrating,
+                    },
+                },
+            )
+        })
+    }
+
+    fn extract_linvel(velocity: &Self::Velocity) -> Vec3 {
+        velocity.linvel.extend(0.0)
+    }
+
+    fn extract_angvel(velocity: &Self::Velocity) -> Vec3 {
+        velocity.angvel * Vec3::Z
+    }
+}
+
+/// Contains common physics settings for character controllers.
+#[derive(Bundle)]
+pub struct Rapier2dControllerPhysicsBundle {
+    /// See [`RigidBody`].
+    pub rigidbody: RigidBody,
+    /// See [`Collider`].
+    pub collider: Collider,
+    /// See [`Velocity`].
+    pub velocity: Velocity,
+    /// See [`GravityScale`].
+    pub gravity: GravityScale,
+    /// See [`Sleeping`].
+    pub sleeping: Sleeping,
+    /// See [`Ccd`].
+    pub ccd: Ccd,
+    /// See [`ExternalImpulse`].
+    pub force: ExternalImpulse,
+    /// See [`LockedAxes`].
+    pub locked_axes: LockedAxes,
+    /// See [`Friction`].
+    pub friction: Friction,
+    /// See [`Damping`].
+    pub damping: Damping,
+    /// See [`Restitution`].
+    pub restitution: Restitution,
+}
+
+impl Default for Rapier2dControllerPhysicsBundle {
+    fn default() -> Self {
+        Self {
+            rigidbody: default(),
+            collider: Collider::capsule(vec2(0.0, 0.0), vec2(0.0, 0.5), 0.5),
+            velocity: default(),
+            gravity: GravityScale(0.0),
+            sleeping: default(),
+            ccd: default(),
+            force: default(),
+            locked_axes: default(),
+            friction: Friction {
+                coefficient: 0.0,
+                combine_rule: CoefficientCombineRule::Min,
+            },
+            damping: Damping {
+                linear_damping: 0.0,
+                angular_damping: 0.0,
+            },
+            restitution: Restitution {
+                coefficient: 0.0,
+                combine_rule: CoefficientCombineRule::Min,
+            },
+        }
+    }
+}
+
+impl BackendCastableShape for Collider {
+    fn ball(radius: f32) -> Self {
+        Collider::ball(radius)
+    }
+}

--- a/src/backends/rapier3d.rs
+++ b/src/backends/rapier3d.rs
@@ -1,0 +1,142 @@
+//! Implementations specific to the 3D version of Rapier.
+
+use super::{BackendCastableShape, PhysicsBackend, TOIStatusProxy, ToiProxy};
+use bevy::{math::*, prelude::*};
+use bevy_rapier3d::prelude::*;
+
+/// A [PhysicsBackend] for using the 3D version of Rapier.
+pub struct Rapier3dBackend;
+
+impl PhysicsBackend for Rapier3dBackend {
+    type ControllerPhysicsBundle = Rapier3dControllerPhysicsBundle;
+    type ExternalImpulse = ExternalImpulse;
+    type Velocity = Velocity;
+    type PhysicsContext = RapierContext;
+    type CastableShape = Collider;
+
+    /// This system adds some tweaks to rapier's physics settings that make the character controller behave better.
+    fn generate_setup_system_set() -> SystemSet {
+        fn setup_physics_context(
+            mut ctx: ResMut<RapierContext>,
+            should_change: Option<Res<crate::WanderlustPhysicsTweaks>>,
+        ) {
+            if should_change.map(|s| s.should_do_tweaks()).unwrap_or(true) {
+                let params = &mut ctx.integration_parameters;
+                // This prevents any noticeable jitter when running facefirst into a wall.
+                params.erp = 0.99;
+                // This prevents (most) noticeable jitter when running facefirst into an inverted corner.
+                params.max_velocity_iterations = 16;
+                // TODO: Fix jitter that occurs when running facefirst into a normal corner.
+            }
+        }
+        SystemSet::new().with_system(setup_physics_context)
+    }
+
+    fn apply_impulses(body: &mut Self::ExternalImpulse, impulse: Vec3, torque_impulse: Vec3) {
+        body.impulse = impulse;
+        body.torque_impulse = torque_impulse;
+    }
+
+    fn entity_has_contacts(ctx: &Self::PhysicsContext, entity: Entity) -> bool {
+        ctx.contacts_with(entity).next().is_some()
+    }
+
+    fn cast_shape(
+        ctx: &Self::PhysicsContext,
+        transofrm: &GlobalTransform,
+        settings: &crate::ControllerSettings<Self::CastableShape>,
+        entity: Entity,
+    ) -> Option<(Entity, ToiProxy)> {
+        ctx.cast_shape(
+            transofrm.mul_vec3(settings.float_cast_origin),
+            transofrm.to_scale_rotation_translation().1,
+            -settings.up_vector,
+            &settings.float_cast_collider,
+            settings.float_cast_length,
+            QueryFilter::new().predicate(&|collider| collider != entity),
+        )
+        .map(|(entity, toi)| {
+            (
+                entity,
+                ToiProxy {
+                    toi: toi.toi,
+                    normal1: toi.normal1,
+                    status: match toi.status {
+                        TOIStatus::OutOfIterations => TOIStatusProxy::OutOfIterations,
+                        TOIStatus::Converged => TOIStatusProxy::Converged,
+                        TOIStatus::Failed => TOIStatusProxy::Failed,
+                        TOIStatus::Penetrating => TOIStatusProxy::Penetrating,
+                    },
+                },
+            )
+        })
+    }
+
+    fn extract_linvel(velocity: &Self::Velocity) -> Vec3 {
+        velocity.linvel
+    }
+
+    fn extract_angvel(velocity: &Self::Velocity) -> Vec3 {
+        velocity.angvel
+    }
+}
+
+/// Contains common physics settings for character controllers.
+#[derive(Bundle)]
+pub struct Rapier3dControllerPhysicsBundle {
+    /// See [`RigidBody`].
+    pub rigidbody: RigidBody,
+    /// See [`Collider`].
+    pub collider: Collider,
+    /// See [`Velocity`].
+    pub velocity: Velocity,
+    /// See [`GravityScale`].
+    pub gravity: GravityScale,
+    /// See [`Sleeping`].
+    pub sleeping: Sleeping,
+    /// See [`Ccd`].
+    pub ccd: Ccd,
+    /// See [`ExternalImpulse`].
+    pub force: ExternalImpulse,
+    /// See [`LockedAxes`].
+    pub locked_axes: LockedAxes,
+    /// See [`Friction`].
+    pub friction: Friction,
+    /// See [`Damping`].
+    pub damping: Damping,
+    /// See [`Restitution`].
+    pub restitution: Restitution,
+}
+
+impl Default for Rapier3dControllerPhysicsBundle {
+    fn default() -> Self {
+        Self {
+            rigidbody: default(),
+            collider: Collider::capsule(vec3(0.0, 0.0, 0.0), vec3(0.0, 0.5, 0.0), 0.5),
+            velocity: default(),
+            gravity: GravityScale(0.0),
+            sleeping: default(),
+            ccd: default(),
+            force: default(),
+            locked_axes: default(),
+            friction: Friction {
+                coefficient: 0.0,
+                combine_rule: CoefficientCombineRule::Min,
+            },
+            damping: Damping {
+                linear_damping: 0.0,
+                angular_damping: 0.0,
+            },
+            restitution: Restitution {
+                coefficient: 0.0,
+                combine_rule: CoefficientCombineRule::Min,
+            },
+        }
+    }
+}
+
+impl BackendCastableShape for Collider {
+    fn ball(radius: f32) -> Self {
+        Collider::ball(radius)
+    }
+}

--- a/src/bundles.rs
+++ b/src/bundles.rs
@@ -1,76 +1,21 @@
-use crate::{ControllerInput, ControllerSettings, ControllerState};
+use crate::{ControllerInput, ControllerSettings, ControllerState, PhysicsBackend};
 
-use bevy::{math::*, prelude::*};
-use bevy_rapier3d::prelude::*;
-
-/// Contains common physics settings for character controllers.
-#[derive(Bundle)]
-pub struct ControllerPhysicsBundle {
-    /// See [`RigidBody`].
-    pub rigidbody: RigidBody,
-    /// See [`Collider`].
-    pub collider: Collider,
-    /// See [`Velocity`].
-    pub velocity: Velocity,
-    /// See [`GravityScale`].
-    pub gravity: GravityScale,
-    /// See [`Sleeping`].
-    pub sleeping: Sleeping,
-    /// See [`Ccd`].
-    pub ccd: Ccd,
-    /// See [`ExternalImpulse`].
-    pub force: ExternalImpulse,
-    /// See [`LockedAxes`].
-    pub locked_axes: LockedAxes,
-    /// See [`Friction`].
-    pub friction: Friction,
-    /// See [`Damping`].
-    pub damping: Damping,
-    /// See [`Restitution`].
-    pub restitution: Restitution,
-}
-
-impl Default for ControllerPhysicsBundle {
-    fn default() -> Self {
-        Self {
-            rigidbody: default(),
-            collider: Collider::capsule(vec3(0.0, 0.0, 0.0), vec3(0.0, 0.5, 0.0), 0.5),
-            velocity: default(),
-            gravity: GravityScale(0.0),
-            sleeping: default(),
-            ccd: default(),
-            force: default(),
-            locked_axes: default(),
-            friction: Friction {
-                coefficient: 0.0,
-                combine_rule: CoefficientCombineRule::Min,
-            },
-            damping: Damping {
-                linear_damping: 0.0,
-                angular_damping: 0.0,
-            },
-            restitution: Restitution {
-                coefficient: 0.0,
-                combine_rule: CoefficientCombineRule::Min,
-            },
-        }
-    }
-}
+use bevy::prelude::*;
 
 /// The recommended bundle for creating a basic, walking character controller. Includes the necessary components for a character controller
 /// as well as many physics-related components that can be used to tweak the behavior of the controller, with reasonable default
 /// values.
 #[derive(Bundle)]
-pub struct CharacterControllerBundle {
+pub struct CharacterControllerBundle<B: PhysicsBackend> {
     /// See [`CharacterController`].
     pub controller: ControllerState,
     /// See [`ControllerSettings`].
-    pub settings: ControllerSettings,
+    pub settings: ControllerSettings<B::CastableShape>,
     /// See [`ControllerInput`].
     pub input: ControllerInput,
-    /// See [`ControllerPhysicsBundle`]
+    /// See [`PhysicsBackend::ControllerPhysicsBundle`]
     #[bundle]
-    pub physics: ControllerPhysicsBundle,
+    pub physics: B::ControllerPhysicsBundle,
     /// See [`Transform`]
     pub transform: Transform,
     /// See [`GlobalTransform`]
@@ -81,7 +26,7 @@ pub struct CharacterControllerBundle {
     pub computed_visibility: ComputedVisibility,
 }
 
-impl Default for CharacterControllerBundle {
+impl<B: PhysicsBackend> Default for CharacterControllerBundle<B> {
     fn default() -> Self {
         Self {
             controller: default(),
@@ -98,16 +43,16 @@ impl Default for CharacterControllerBundle {
 
 /// A flying character controller with spaceship-like controls.
 #[derive(Bundle)]
-pub struct StarshipControllerBundle {
+pub struct StarshipControllerBundle<B: PhysicsBackend> {
     /// See [`ControllerState`].
     pub controller: ControllerState,
     /// See [`ControllerSettings`].
-    pub settings: ControllerSettings,
+    pub settings: ControllerSettings<B::CastableShape>,
     /// See [`ControllerInput`].
     pub input: ControllerInput,
-    /// See [`ControllerPhysicsBundle`].
+    /// See [`PhysicsBackend::ControllerPhysicsBundle`]
     #[bundle]
-    pub physics: ControllerPhysicsBundle,
+    pub physics: B::ControllerPhysicsBundle,
     /// See [`Transform`]
     pub transform: Transform,
     /// See [`GlobalTransform`]
@@ -118,7 +63,7 @@ pub struct StarshipControllerBundle {
     pub computed_visibility: ComputedVisibility,
 }
 
-impl Default for StarshipControllerBundle {
+impl<B: PhysicsBackend> Default for StarshipControllerBundle<B> {
     fn default() -> Self {
         Self {
             controller: default(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![deny(missing_docs)]
 #![doc = include_str!("../README.md")]
 
+pub mod backends;
 mod bundles;
 mod components;
 mod plugins;
@@ -9,10 +10,11 @@ mod resources;
 mod systems;
 
 pub use self::{
-    bundles::{CharacterControllerBundle, ControllerPhysicsBundle, StarshipControllerBundle},
+    backends::PhysicsBackend,
+    bundles::{CharacterControllerBundle, StarshipControllerBundle},
     components::{ControllerInput, ControllerSettings, ControllerState},
     plugins::WanderlustPlugin,
     presets::{CharacterControllerPreset, StarshipControllerPreset},
     resources::WanderlustPhysicsTweaks,
-    systems::{movement, setup_physics_context},
+    systems::movement,
 };

--- a/src/plugins.rs
+++ b/src/plugins.rs
@@ -3,14 +3,14 @@ use bevy::prelude::*;
 
 /// The [character controller](CharacterController) plugin. Necessary to have the character controller
 /// work.
-pub struct WanderlustPlugin;
+pub struct WanderlustPlugin<B: crate::PhysicsBackend>(pub B);
 
-impl Plugin for WanderlustPlugin {
+impl<B: crate::PhysicsBackend> Plugin for WanderlustPlugin<B> {
     fn build(&self, app: &mut App) {
         app.register_type::<ControllerState>()
-            .register_type::<ControllerSettings>()
+            .register_type::<ControllerSettings<B::CastableShape>>()
             .register_type::<ControllerInput>()
-            .add_startup_system(setup_physics_context)
-            .add_system(movement);
+            .add_startup_system_set(B::generate_setup_system_set())
+            .add_system(movement::<B>);
     }
 }

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -1,13 +1,13 @@
+use crate::backends::BackendCastableShape;
 use crate::ControllerSettings;
 use bevy::math::vec3;
 use bevy::prelude::*;
-use bevy_rapier3d::prelude::Collider;
 
 /// A basic preset for a standard, walking character controller. Works for most first and third person games.
 pub struct CharacterControllerPreset;
 
-impl From<CharacterControllerPreset> for ControllerSettings {
-    fn from(_: CharacterControllerPreset) -> ControllerSettings {
+impl<C: BackendCastableShape> From<CharacterControllerPreset> for ControllerSettings<C> {
+    fn from(_: CharacterControllerPreset) -> ControllerSettings<C> {
         ControllerSettings {
             acceleration: 50.0,
             max_speed: 10.0,
@@ -26,7 +26,7 @@ impl From<CharacterControllerPreset> for ControllerSettings {
             jump_buffer_duration: 0.16,
             force_scale: vec3(1.0, 0.0, 1.0),
             float_cast_length: 1.0,
-            float_cast_collider: Collider::ball(0.45),
+            float_cast_collider: C::ball(0.45),
             float_distance: 0.55,
             float_strength: 10.0,
             float_dampen: 0.5,
@@ -40,8 +40,8 @@ impl From<CharacterControllerPreset> for ControllerSettings {
 /// A sample controller preset for a spaceship which can fly in any direction.
 pub struct StarshipControllerPreset;
 
-impl From<StarshipControllerPreset> for ControllerSettings {
-    fn from(_: StarshipControllerPreset) -> ControllerSettings {
+impl<C: BackendCastableShape> From<StarshipControllerPreset> for ControllerSettings<C> {
+    fn from(_: StarshipControllerPreset) -> ControllerSettings<C> {
         ControllerSettings {
             acceleration: 0.3,
             max_speed: 100.0,


### PR DESCRIPTION
I'm not very happy with how this turned out, but I figured since I already put the work I might make a PR to get some feedback.

The README says you want to support 2D  and that maybe to "Become agnostic to physics backend". Because Rapier3D and Rapier2D are separate crates, supporting 2D already require some level of agnosticism to the physics backend because the concrete types need to be generic - but I don't think what I did here is enough to support other physics backends. I did rely on the fact that Rapier2D and Rapier3D have an identical architecture. For example - both require a single resource (`RapierContext`) to do a shape cast, and use the same resource to check for contacts. But other physics engines may need different resources for these, or they may need multiple resources for one of these checks, or maybe they'll need access to components.

This PR is an OOP solution to the problem, and having a truly backend agnostic OOP solution would require GAT. But even with GAT (which was just merged, so we'll have to wait to Rust 1.65 to use it) that solution will be ugly and verbose, and adding new features will be difficult.

So... I'm thinking of trying to implement a more ECS solution. This means splitting `movement` to 3 systems:

1. A system that queries the physics data and checks the entity's collisions and distance from the ground.
2. A system that calculates the forces needed to apply the movement.
3. A system that applies these forces.

The first and third system will be backend-specific, but the second system - where most of the logic will reside - will be backend agnostic.

This will be a bigger change, but I think it'll be worth it because in addition to allowing non-Rapier backends, it will also make it easier to add new features. For example - if we want to add the first feature in the list, wallrunning, we can make the Rapier3D implementation of the first system figure out if the player can wallrun and add (or modify) a component for storing that information for the second system to use. The Rapier2D backend - where wallrunning makes sense - will simply not detect the wallrun. Compare to the OOP solution, where the trait will have to get more complicated to be able to tell if the player is in a wallrunning position - and when we'll have to implement it for all the backends that implement the trait or else they'll be broken.

I'm posting this PR as a proof of seriousness and a place for discussion, but at this point I'm not planning to rebase it or otherwise fix the conflicts. Instead, I want to try to make this ECS solution I've described. Hopefully I'll get to it within the weekend.