### PR TITLE
`RelatedEntities` component and more intuitive spring settings

### DIFF
--- a/examples/first_person.rs
+++ b/examples/first_person.rs
@@ -8,6 +8,11 @@ use bevy_rapier3d::prelude::*;
 
 fn main() {
     App::new()
+        .insert_resource(WindowDescriptor {
+            cursor_locked: true,
+            cursor_visible: false,
+            ..default()
+        })
         .add_plugins(DefaultPlugins)
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
         .add_plugin(RapierDebugRenderPlugin::default())

--- a/src/bundles.rs
+++ b/src/bundles.rs
@@ -55,7 +55,7 @@ impl Default for ControllerPhysicsBundle {
                 coefficient: 0.0,
                 combine_rule: CoefficientCombineRule::Min,
             },
-            read_mass_properties: ReadMassProperties::default(),
+            read_mass_properties: default(),
         }
     }
 }

--- a/src/bundles.rs
+++ b/src/bundles.rs
@@ -28,6 +28,8 @@ pub struct ControllerPhysicsBundle {
     pub damping: Damping,
     /// See [`Restitution`].
     pub restitution: Restitution,
+    /// See [`ReadMassProperties`].
+    pub read_mass_properties: ReadMassProperties,
 }
 
 impl Default for ControllerPhysicsBundle {
@@ -53,6 +55,7 @@ impl Default for ControllerPhysicsBundle {
                 coefficient: 0.0,
                 combine_rule: CoefficientCombineRule::Min,
             },
+            read_mass_properties: ReadMassProperties::default(),
         }
     }
 }

--- a/src/components.rs
+++ b/src/components.rs
@@ -1,4 +1,4 @@
-use bevy::{math::*, prelude::*};
+use bevy::{math::*, prelude::*, utils::HashSet};
 use bevy_rapier3d::prelude::*;
 
 use crate::{CharacterControllerPreset, StarshipControllerPreset};
@@ -179,4 +179,12 @@ pub struct ControllerInput {
     /// which rapier uses to apply impulse forces to a rigidbody.
     /// Will be reset to 0 after being applied.
     pub custom_torque: Vec3,
+}
+
+/// Entities that should be considered as part of the controlled character.
+#[derive(Deref, DerefMut, Component, Default, Reflect)]
+#[reflect(Component)]
+pub struct RelatedEntities {
+    /// Set of entities that should be considered a part of the same character.
+    pub related: HashSet<Entity>,
 }

--- a/src/components.rs
+++ b/src/components.rs
@@ -105,6 +105,8 @@ pub struct ControllerSettings {
     pub float_spring: Spring,
     /// How strongly to force the character upright/avoid overshooting. Alternatively, see [`LockedAxes`] to lock rotation entirely.
     pub upright_spring: Spring,
+    /// Set of entities that should be ignored when ground casting.
+    pub exclude_from_ground: HashSet<Entity>,
 }
 
 impl ControllerSettings {
@@ -147,6 +149,7 @@ impl Default for ControllerSettings {
             float_distance: default(),
             float_spring: default(),
             upright_spring: default(),
+            exclude_from_ground: default(),
         }
     }
 }
@@ -173,12 +176,4 @@ pub struct ControllerInput {
     /// which rapier uses to apply impulse forces to a rigidbody.
     /// Will be reset to 0 after being applied.
     pub custom_torque: Vec3,
-}
-
-/// Entities that should be considered as part of the controlled character.
-#[derive(Deref, DerefMut, Component, Default, Reflect)]
-#[reflect(Component)]
-pub struct RelatedEntities {
-    /// Set of entities that should be considered a part of the same character.
-    pub related: HashSet<Entity>,
 }

--- a/src/components.rs
+++ b/src/components.rs
@@ -1,7 +1,7 @@
 use bevy::{math::*, prelude::*, utils::HashSet};
 use bevy_rapier3d::prelude::*;
 
-use crate::{CharacterControllerPreset, StarshipControllerPreset};
+use crate::{CharacterControllerPreset, Spring, StarshipControllerPreset};
 
 /// The character controller's state.
 /// This is the component responsible for adding controls to an entity.
@@ -102,13 +102,9 @@ pub struct ControllerSettings {
     /// How far to attempt to float away from the ground.
     pub float_distance: f32,
     /// How strongly to float away from the ground.
-    pub float_strength: f32,
-    /// How strongly to dampen floating away from the ground, to prevent jittering/oscillating float movement.
-    pub float_dampen: f32,
-    /// How strongly to attempt to stay upright. Alternatively, see [`LockedAxes`] to lock rotation entirely.
-    pub upright_spring_strength: f32,
-    /// How strongly to dampen staying upright. Prevents jittering/oscillating upright movement.
-    pub upright_spring_damping: f32,
+    pub float_spring: Spring,
+    /// How strongly to force the character upright/avoid overshooting. Alternatively, see [`LockedAxes`] to lock rotation entirely.
+    pub upright_spring: Spring,
 }
 
 impl ControllerSettings {
@@ -149,10 +145,8 @@ impl Default for ControllerSettings {
             float_cast_origin: default(),
             float_cast_collider: Collider::ball(1.0),
             float_distance: default(),
-            float_strength: default(),
-            float_dampen: default(),
-            upright_spring_strength: default(),
-            upright_spring_damping: default(),
+            float_spring: default(),
+            upright_spring: default(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ mod systems;
 
 pub use self::{
     bundles::{CharacterControllerBundle, ControllerPhysicsBundle, StarshipControllerBundle},
-    components::{ControllerInput, ControllerSettings, ControllerState, RelatedEntities},
+    components::{ControllerInput, ControllerSettings, ControllerState},
     plugins::WanderlustPlugin,
     presets::{CharacterControllerPreset, StarshipControllerPreset},
     resources::WanderlustPhysicsTweaks,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ mod systems;
 
 pub use self::{
     bundles::{CharacterControllerBundle, ControllerPhysicsBundle, StarshipControllerBundle},
-    components::{ControllerInput, ControllerSettings, ControllerState},
+    components::{ControllerInput, ControllerSettings, ControllerState, RelatedEntities},
     plugins::WanderlustPlugin,
     presets::{CharacterControllerPreset, StarshipControllerPreset},
     resources::WanderlustPhysicsTweaks,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod components;
 mod plugins;
 mod presets;
 mod resources;
+mod spring;
 mod systems;
 
 pub use self::{
@@ -14,5 +15,6 @@ pub use self::{
     plugins::WanderlustPlugin,
     presets::{CharacterControllerPreset, StarshipControllerPreset},
     resources::WanderlustPhysicsTweaks,
+    spring::Spring,
     systems::{movement, setup_physics_context},
 };

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -13,7 +13,7 @@ impl From<CharacterControllerPreset> for ControllerSettings {
             max_speed: 10.0,
             max_acceleration_force: 10.0,
             up_vector: Vec3::Y,
-            gravity: 25.0,
+            gravity: -9.8,
             max_ground_angle: 45.0 * (std::f32::consts::PI / 180.0),
             min_float_offset: -0.3,
             max_float_offset: 0.05,

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -1,4 +1,4 @@
-use crate::ControllerSettings;
+use crate::{ControllerSettings, Spring};
 use bevy::math::vec3;
 use bevy::prelude::*;
 use bevy_rapier3d::prelude::Collider;
@@ -28,10 +28,14 @@ impl From<CharacterControllerPreset> for ControllerSettings {
             float_cast_length: 1.0,
             float_cast_collider: Collider::ball(0.45),
             float_distance: 0.55,
-            float_strength: 10.0,
-            float_dampen: 0.5,
-            upright_spring_strength: 100.0,
-            upright_spring_damping: 10.0,
+            float_spring: Spring {
+                strength: 10.0,
+                damping: 0.5,
+            },
+            upright_spring: Spring {
+                strength: 10.0,
+                damping: 0.5,
+            },
             ..default()
         }
     }

--- a/src/spring.rs
+++ b/src/spring.rs
@@ -1,0 +1,39 @@
+use bevy::{math::*, prelude::*};
+
+/// Spring parameters for a dampened harmonic oscillator.
+///
+/// Some good readings on this:
+/// - https://www.ryanjuckett.com/damped-springs/
+/// - https://gafferongames.com/post/spring_physics/
+#[derive(Debug, Clone, Copy, Reflect)]
+pub struct Spring {
+    /// How strong the spring will push it into position.
+    pub strength: f32,
+    /// Damping ratio for the spring, this prevents endless oscillation if greater than 0.
+    /// <1 is under-dampened so it will overshoot the target
+    /// 1 is critically dampened so it will slow just enough to reach the target without overshooting
+    /// >1 is over-dampened so it will reach the target slowly.
+    pub damping: f32,
+}
+
+impl Default for Spring {
+    fn default() -> Self {
+        Self {
+            strength: 1.0,
+            damping: 0.25,
+        }
+    }
+}
+
+impl Spring {
+    /// The damping coefficient that will just reach the target without overshooting.
+    pub fn critical_damping_point(&self, mass: f32) -> f32 {
+        2.0 * (mass * self.strength).sqrt()
+    }
+
+    /// Get the correct damping coefficient for our damping ratio.
+    /// See [`Spring`]'s damping for more information on the ratio.
+    pub fn damp_coefficient(&self, mass: f32) -> f32 {
+        self.damping * self.critical_damping_point(mass)
+    }
+}

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -96,7 +96,7 @@ pub fn movement(
 
         // Gravity
         let gravity = if ground_cast.is_none() {
-            -settings.up_vector * settings.gravity
+            settings.up_vector * mass * settings.gravity * dt
         } else {
             Vec3::ZERO
         };
@@ -122,6 +122,7 @@ pub fn movement(
             (-settings.up_vector)
                 * ((snap * settings.float_spring.strength)
                     - (relative_align * settings.float_spring.damp_coefficient(mass)))
+                * dt
         } else {
             ground_vel = None;
             Vec3::ZERO
@@ -142,7 +143,7 @@ pub fn movement(
             let goal_vel = Vec3::lerp(
                 controller.last_goal_velocity,
                 input_goal_vel + ground_vel.map(|v| v.linvel).unwrap_or(Vec3::ZERO),
-                accel.min(1.0),
+                (accel * dt).min(1.0),
             );
 
             let needed_accel = goal_vel - velocity.linvel;
@@ -169,7 +170,7 @@ pub fn movement(
         let mut jump = if controller.jump_timer > 0.0 && !grounded {
             if !input.jumping {
                 controller.jump_timer = 0.0;
-                velocity.linvel.project_onto(settings.up_vector) * -settings.jump_stop_force
+                velocity.linvel.project_onto(settings.up_vector) * -settings.jump_stop_force * dt
             } else {
                 controller.jump_timer = (controller.jump_timer - dt).max(0.0);
 
@@ -181,6 +182,7 @@ pub fn movement(
                     * (settings.jump_decay_function)(
                         (settings.jump_time - controller.jump_timer) / settings.jump_time,
                     )
+                    * dt
             }
         } else {
             Vec3::ZERO
@@ -216,7 +218,7 @@ pub fn movement(
             };
 
             (to_goal_axis * (to_goal_angle * settings.upright_spring.strength))
-                - (velocity.angvel * settings.upright_spring.damp_coefficient(mass))
+                - (velocity.angvel * settings.upright_spring.damp_coefficient(mass)) * dt
         };
 
         // Apply positional force to the rigidbody

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -28,7 +28,7 @@ pub fn movement(
     {
         let dt = time.delta_seconds();
         let mass = mass_properties.0.mass;
-        let center_of_mass = mass_properties.0.local_center_of_mass;
+        let local_center_of_mass = mass_properties.0.local_center_of_mass;
 
         // Sometimes, such as at the beginning of the game, deltatime is 0. This
         // can cause division by 0 so I just skip those frames. A better solution
@@ -111,7 +111,9 @@ pub fn movement(
         let mut float_spring = if let Some((ground, intersection)) = ground_cast {
             ground_vel = velocities.get(ground).ok();
 
-            let vel_align = (-settings.up_vector).dot(velocity.linvel);
+            let point_velocity =
+                velocity.linvel + velocity.angvel.cross(Vec3::ZERO - local_center_of_mass);
+            let vel_align = (-settings.up_vector).dot(point_velocity);
             let ground_vel_align =
                 (-settings.up_vector).dot(ground_vel.map(|v| v.linvel).unwrap_or(Vec3::ZERO));
 


### PR DESCRIPTION
Swap from directly using the damp_coefficient in `F = -kx - cv` to using a ratio to the critical damping point.

This means that damping forces should make more sense in that
<1 is under-damped and will overshoot
1 is critically damped and will just reach the target without overshooting
\>1 is over-damped and will slowly reach the target