### PR TITLE
Add is_grounded to ControllerState

### DIFF
--- a/src/components/state.rs
+++ b/src/components/state.rs
@@ -24,4 +24,6 @@ pub struct ControllerState {
     pub jump_buffer_timer: f32,
     /// How many extra jumps are remaining
     pub remaining_jumps: u32,
+    /// Is the character firmly grounded (and thus able to jump)
+    pub is_grounded: bool,
 }

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -305,6 +305,7 @@ pub fn movement(
         }
 
         controller.jump_pressed_last_frame = input.jumping;
+        controller.is_grounded = grounded;
     }
 }
 


### PR DESCRIPTION
Adds a public field to tell if the player is grounded this frame or not.